### PR TITLE
Use Amazon Linux 2, newer version of R and paws for AWS api interaction

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -1,8 +1,8 @@
-FROM public.ecr.aws/lambda/provided
+FROM public.ecr.aws/lambda/provided:al2
 
-ENV R_VERSION=4.0.3
+ENV R_VERSION=4.1.2
 
-RUN yum -y install wget
+RUN yum -y install wget libxml2-devel
 
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
   && wget https://cdn.rstudio.com/r/centos-7/pkgs/R-${R_VERSION}-1-1.x86_64.rpm \
@@ -12,9 +12,9 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 ENV PATH="${PATH}:/opt/R/${R_VERSION}/bin/"
 
 # System requirements for R packages
-RUN yum -y install openssl-devel
+RUN yum -y install tar openssl-devel
 
-RUN Rscript -e "install.packages(c('httr', 'jsonlite', 'logger', 'logging'), repos = 'https://cloud.r-project.org/')"
+RUN Rscript -e "install.packages(c('httr', 'jsonlite', 'logger', 'logging', 'paws', 'arrow'), repos = 'https://cloud.r-project.org/')"
 
 
 COPY runtime.R functions.R bootstrap.R ${LAMBDA_TASK_ROOT}/


### PR DESCRIPTION
Hello @ramonmarrero,

Thanks for this repo and your [accompanying writeup](https://medium.com/geekculture/effectively-running-r-scripts-from-aws-lambda-functions-6af85caa1571). On this PR I have bumped the R version and used `provided:al2`, which is a newer/better base for lambda runtimes on AWS. I've tested it with the newly released [CDKv2](https://aws.amazon.com/blogs/aws/announcing-general-availability-of-construct-hub-and-aws-cloud-development-kit-version-2/) and works fab, btw.

Also, I've added the [paws](https://paws-r.github.io/) AWS R SDK that allows very easy interaction with a bunch of AWS services and [arrow](https://www.r-bloggers.com/2021/09/understanding-the-parquet-file-format/), which helps a ton with data handling workflows on AWS (since Parquet is a first class citizen format for SerDe on AWS).

I hope you don't mind merging those changes to make your example repo even more useful for other folks?